### PR TITLE
Changed prog variable to point to python script.

### DIFF
--- a/init/rhel/graphios
+++ b/init/rhel/graphios
@@ -17,7 +17,7 @@
 # Check that networking is up.
 [ "$NETWORKING" = "no" ] && exit 0
 
-prog="/usr/bin/graphios"
+prog="/usr/bin/graphios.py"
 # or use the command line options:
 #prog="/usr/bin/graphios --log-file=/dir/mylog.log --spool-directory=/dir/my/sool"
 GRAPHIOS_USER="nagios"


### PR DESCRIPTION
Fixes issue of "sudo: /usr/bin/graphios: command not found" when trying to start the service on Centos 6.2. Haven't tested on other versions.